### PR TITLE
Fix Imap.php: Delete-Flag work's, but can't remove mail from server/mailbox

### DIFF
--- a/Imap.php
+++ b/Imap.php
@@ -158,6 +158,7 @@ class Imap extends Base
     public function disconnect()
     {
         if ($this->socket) {
+            $this->send('CLOSE');
             $this->send('LOGOUT');
 
             fclose($this->socket);


### PR DESCRIPTION
You need to send "CLOSE" before "LOGOUT" to remove delete-flagged messages from active message box - or: provide (at least) a function to do so manually

Fix (partly) issue #1
