### PR TITLE
added regex to skip a incomplete FETCH or TAG line

### DIFF
--- a/src/Imap.php
+++ b/src/Imap.php
@@ -1066,7 +1066,9 @@ class Imap extends Base
                 preg_match('/^\* [0-9]+/', $line, $arr);
                 // no match, there isn't sufficient information to parse the email. Skipping.
                 // potential exception: undefined $flags
-                if (empty($arr)) continue;
+                if (empty($arr)) {
+                    continue;
+                }
 
                 //if there is email data
                 if (!empty($email)) {

--- a/src/Imap.php
+++ b/src/Imap.php
@@ -1059,6 +1059,15 @@ class Imap extends Base
             //if the line starts with a fetch
             //it means it's the end of getting an email
             if (strpos($line, 'FETCH') !== false && strpos($line, 'TAG'.$this->tag) === false) {
+                /**
+                 * simple regex to match the FETCH line
+                 * used to skip over a $line that hasn't got to do with the FETCH or TAG line
+                 */
+                preg_match('/^\* [0-9]+/', $line, $arr);
+                // no match, there isn't sufficient information to parse the email. Skipping.
+                // potential exception: undefined $flags
+                if (empty($arr)) continue;
+
                 //if there is email data
                 if (!empty($email)) {
                     //create the email format and add it to emails


### PR DESCRIPTION
sometimes a FETCH or TAG line is parsed while it isn't a FETCH or TAG
line. This little regex tries to prevent that.

For example: ` * branch feature/PROJECT-12` this leads to an Exception
that the $flags variable is undefined. Which is true because there is no
flag in that line.

Signed-off-by: Tonko Mulder <tonko@tonkomulder.nl>