### PR TITLE
fix imap_binary() call, which returns base64 encoded text

### DIFF
--- a/src/Imap.php
+++ b/src/Imap.php
@@ -29,72 +29,72 @@ class Imap extends Base
      * @const string NO_SUBJECT Default subject
      */
     const NO_SUBJECT = '(no subject)';
-       
+
     /**
      * @var string $host The IMAP Host
      */
     protected $host = null;
-       
+
     /**
      * @var string|null $port The IMAP port
      */
     protected $port = null;
-       
+
     /**
      * @var bool $ssl Whether to use SSL
      */
     protected $ssl = false;
-       
+
     /**
      * @var bool $tls Whether to use TLS
      */
     protected $tls = false;
-       
+
     /**
      * @var string|null $username The mailbox user name
      */
     protected $username = null;
-       
+
     /**
      * @var string|null $password The mailbox password
      */
     protected $password = null;
-       
+
     /**
      * @var int $tag The tag number
      */
     protected $tag = 0;
-       
+
     /**
      * @var int $total The total main in mailbox
      */
     protected $total = 0;
-       
+
     /**
      * @var int $next for pagination
      */
     protected $next = 0;
-       
+
     /**
      * @var string|null $buffer Mail body
      */
     protected $buffer = null;
-       
+
     /**
      * @var [RESOURCE] $socket The socket connection
      */
     protected $socket = null;
-       
+
     /**
      * @var string|null $mailbox The mailbox name
      */
     protected $mailbox = null;
-       
+
     /**
      * @var array $mailboxes The list of mailboxes
      */
     protected $mailboxes = array();
-       
+
     /**
      * @var bool $debugging If true outputs the logs
      */
@@ -462,7 +462,7 @@ class Imap extends Base
 
         return $this;
     }
-    
+
     /**
      * Remove an email from a mailbox
      *
@@ -470,9 +470,9 @@ class Imap extends Base
      */
     public function expunge()
     {
-        
+
         $this->call('expunge');
-                    
+
         return $this;
     }
 
@@ -1291,7 +1291,7 @@ class Imap extends Base
                 switch (strtolower($head['content-transfer-encoding'])) {
                     case 'binary':
                         $body = imap_binary($body);
-                        break;
+                        // break intentionally omitted, imap_binary returns base64 string
                     case 'base64':
                         $body = base64_decode($body);
                         break;


### PR DESCRIPTION
imap_binary returns base64 encoded text, so it needs to be converted to binary