### PR TITLE
Error parsing base64 attachment with a TAG within it

### DIFF
--- a/src/Imap.php
+++ b/src/Imap.php
@@ -1150,7 +1150,7 @@ class Imap extends Base
             }
 
             //if there is a tag it means we are at the end
-            if (strpos($line, 'TAG'.$this->tag) !== false) {
+            if (strpos($line, 'TAG'.$this->tag) === 0) {
                 //if email details are not empty and the last line is just a )
                 if (!empty($email) && strpos(trim($email[count($email) -1]), ')') === 0) {
                     //take it out because that is not part of the details

--- a/src/Imap.php
+++ b/src/Imap.php
@@ -1340,6 +1340,19 @@ class Imap extends Base
             if (isset($extra['name'])) {
                 //add to parts
                 $parts['attachment'][$extra['name']][$type] = $body;
+            } elseif (isset($head['content-disposition']) && strpos($head['content-disposition'],'attachment')===0) {
+                //add to parts
+                //split the content type
+                $filename=null;
+                if (is_string($head['content-disposition'])&&strpos($head['content-disposition'],'filename=')!==false) {
+                        if(preg_match("/filename=([^;]*)/",$head['content-disposition'],$matches)) {
+                                $filename=$matches[1];
+                        }
+                }
+                if($filename)
+                        $parts['attachment'][$filename][$type] = $body;
+                else
+                        $parts['attachment'][][$type] = $body;
             } else {
                 //it's just a regular body
                 //add to parts

--- a/src/Index.php
+++ b/src/Index.php
@@ -33,10 +33,11 @@ class Index extends Base
      * @param int|null $port The IMAP port
      * @param bool     $ssl  Whether to use SSL
      * @param bool     $tls  Whether to use TLS
+     * @param *string|null $xoauth2token The oauth2token
      *
      * @return Eden\Mail\Imap
      */
-    public function imap($host, $user, $pass, $port = null, $ssl = false, $tls = false)
+    public function imap($host, $user, $pass, $port = null, $ssl = false, $tls = false, $xoauth2token = null)
     {
         Argument::i()
             ->test(1, 'string')
@@ -44,9 +45,10 @@ class Index extends Base
             ->test(3, 'string')
             ->test(4, 'int', 'null')
             ->test(5, 'bool')
-            ->test(6, 'bool');
+            ->test(6, 'bool')
+            ->test(7, 'string', 'null');
             
-        return Imap::i($host, $user, $pass, $port, $ssl, $tls);
+        return Imap::i($host, $user, $pass, $port, $ssl, $tls, $xoauth2token);
     }
     
     /**


### PR DESCRIPTION
I've been hit with an attachment base64 encoded which had within it this line:
NZMILlQ0yRDoTAG4A7x9My2IHtBfnwmE1UB3dBn2toYHEdZR3xmOsIJmCrJWu9xCWNXMdCYB1gHd
Where you can see a "TAG4" within it, which truncated the email.
I'm no IMAP expert, so I'm not sure this will break in any other way.